### PR TITLE
Move card page under playground

### DIFF
--- a/src/pages/playground/card.astro
+++ b/src/pages/playground/card.astro
@@ -1,0 +1,55 @@
+---
+import Layout from '../../layouts/Base.astro';
+---
+
+<Layout title="名刺">
+  <main class="meishi">
+    <h1>YUSAMA</h1>
+    <div class="links">
+      <a href="https://twitter.com/YUSAMA_RTA">X(Twitter)</a>
+      <a href="https://www.youtube.com/@yusama18">Youtube</a>
+      <a href="https://github.com/yusama125718">GitHub</a>
+    </div>
+  </main>
+</Layout>
+
+<style>
+  .container {
+    overflow-y: hidden;
+    height: 100vh;
+  }
+
+  .meishi {
+    height: calc(100vh - 100px);
+    background-image: url('../../assets/images/backimg.webp');
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 30px;
+  }
+
+  h1 {
+    padding: 5px 15px;
+    color: #FFF;
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+
+  .links a {
+    display: inline-block;
+    margin: 0 15px;
+    font-size: 28px;
+    text-decoration: none;
+    color: #FFF;
+    background-color: rgba(0, 0, 0, 0.5);
+    padding: 10px 20px;
+    border-radius: 8px;
+  }
+
+  .links a:hover {
+    background-color: rgba(0, 0, 0, 0.8);
+  }
+</style>

--- a/src/pages/playground/index.astro
+++ b/src/pages/playground/index.astro
@@ -8,5 +8,6 @@ import Layout from '../../layouts/Blog.astro';
     <p>色々な遊びをしています。</p>
     <a href="/playground/rubywasm-1"><h3>rubyで文字化け直すやつ</h3></a>
     <a href="/playground/creative-1"><h3>クリエイティブコーディングってやつ</h3></a>
+    <a href="/playground/card"><h3>CodeX製名刺</h3></a>
   </main>
 </Layout>


### PR DESCRIPTION
## Summary
- move card page to `pages/playground/card.astro`
- add link titled `CodeX製名刺` on playground index page

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c31892dc832e899a77aa268a3236